### PR TITLE
Fit check and shift text layers to ensure they are not cut off

### DIFF
--- a/src/CanvasRender/basicRender/index.js
+++ b/src/CanvasRender/basicRender/index.js
@@ -50,7 +50,7 @@ export const basicRender = (props, ctx) => {
         ctx.fillStyle = d.fill || theme.textFill
         ctx.textAlign = d.textAlign || 'left'
         ctx.textBaseline = d.textBaseline || 'alphabetic'
-        ctx.translate(d.x + (d.xOffset || 0), d.y + (d.yOffset || 0))
+        ctx.translate(d.x, d.y)
         ctx.rotate(d.rotate)
         ctx.fillText(d.text, 0, 0)
         ctx.restore()

--- a/src/Layer/text/index.js
+++ b/src/Layer/text/index.js
@@ -5,12 +5,13 @@ import {getMinX, getMinY} from '../../utils/rectUtils'
 import {getMidX, getMidY} from '../../utils/rectUtils'
 import {getMaxX, getMaxY} from '../../utils/rectUtils'
 import {getPlotValues} from '../../Layer/getPlotValues'
+import {fitCheckText} from '../../utils/textUtils'
 
 /*
 generates the array of render data
 */
 export const getTextRenderData = (props, datum, idx) => {
-  const {plotRect} = props
+  const {plotRect, theme, width, height} = props
   const values = getPlotValues(props, datum, idx, {
     x: getMidX(props.plotRect),
     y: getMidY(props.plotRect),
@@ -37,8 +38,10 @@ export const getTextRenderData = (props, datum, idx) => {
     values.y = getMaxY(plotRect)
   }
 
+  const newValues = fitCheckText(values, width, height, theme)
+
   return {
-    ...values,
+    ...newValues,
     type: 'text',
   }
 }

--- a/src/Layer/text/index.test.js
+++ b/src/Layer/text/index.test.js
@@ -3,6 +3,7 @@
 import {it as test} from 'mocha'
 import assert from 'assert'
 import {PLOT_RECT as plotRect} from '../../chartCore/defaults'
+import {DEFAULT_THEME as defaultTheme} from '../../defaultTheme'
 
 import {text} from './'
 
@@ -11,7 +12,9 @@ test('Chart/text 1', () => {
     data: [{x1: 1, x2: 1}],
     xScale: d => d,
     yScale: d => d,
+    textValue: 'a',
     plotRect,
+    theme: defaultTheme,
   })
   assert.deepEqual(renderData[0].type, 'text')
 })
@@ -19,6 +22,8 @@ test('Chart/text missing scales', () => {
   const renderData = text({
     data: [{x1: 1, x2: 1}],
     plotRect,
+    textValue: 'a',
+    theme: defaultTheme,
   })
   assert.deepEqual(renderData, undefined)
 })
@@ -27,7 +32,9 @@ test('Chart/text grouped data', () => {
     data: [[{x1: 1, x2: 1}]],
     xScale: d => d,
     yScale: d => d,
+    textValue: 'a',
     plotRect,
+    theme: defaultTheme,
   })
   assert.deepEqual(renderData[0].type, 'text')
 })

--- a/src/utils/canvasUtils/index.js
+++ b/src/utils/canvasUtils/index.js
@@ -15,9 +15,7 @@ export const ctxMock = {
   isPointInPath: noop,
   isPointInStroke: noop,
   lineTo: noop,
-  measureText(text) {
-    return {width: text.toString().length}
-  },
+  measureText: (text) => ({width: text.toString().length}),
   arcTo: noop,
   moveTo: noop,
   quadraticCurveTo: noop,

--- a/src/utils/textUtils/index.js
+++ b/src/utils/textUtils/index.js
@@ -1,0 +1,32 @@
+import {update} from 'lodash'
+import {getTextWidth} from '../../chartCore/getPlotRect'
+
+export const fitCheckText = (textObj, canvasWidth, canvasHeight, theme) => {
+  const updateTextObj = (key, toAdd) => update(textObj, key, val => val + toAdd)
+
+  const {x} = updateTextObj('x', textObj.xOffset || 0)
+  const {y} = updateTextObj('y', textObj.yOffset || 0)
+  const isRotated = Boolean(textObj.rotate)
+
+  const {textStart, textEnd} = getTextBounds(textObj, isRotated, theme)
+
+  const overFlow = textEnd - (isRotated ? canvasHeight : canvasWidth)
+  const underFlow = -textStart
+
+  const shift = overFlow > 0 ? -overFlow : underFlow > 0 ? underFlow : 0
+
+  return updateTextObj(isRotated ? 'y' : 'x', shift)
+}
+
+const getTextBounds = (textObj, isRotated, theme) => {
+  const textAlign = textObj.textAlign || 'left'
+  const textWidth = getTextWidth(theme, textObj.text) * (textAlign === 'center' ? .5 : 1)
+  const initialCoord = isRotated ? textObj.y : textObj.x
+  const rightAligned = ['right', 'end'].includes(textAlign)
+  const leftAligned = ['left', 'start'].includes(textAlign)
+
+  return {
+    textStart: !(isRotated ^ leftAligned) ? initialCoord - textWidth : initialCoord,
+    textEnd: !(isRotated ^ rightAligned) ? initialCoord + textWidth : initialCoord,
+  }
+}

--- a/src/utils/textUtils/index.test.js
+++ b/src/utils/textUtils/index.test.js
@@ -1,0 +1,133 @@
+import {it as test, describe, beforeEach} from 'mocha'
+import assert from 'assert'
+
+import {fitCheckText} from './'
+import {DEFAULT_THEME as defaultTheme} from '../../defaultTheme'
+
+describe('utils.fitCheckText', () => {
+  let textData
+  const width = 1000
+  const height = 1000
+
+  beforeEach(() => {
+    textData = {
+      text: 'text with a length of 25.',
+      x: 250,
+      y: 125,
+    }
+  })
+
+  test('utils.fitCheckText does not shift if fits on canvas', () => {
+    assert.deepEqual(
+      fitCheckText(textData, width, height, defaultTheme),
+      {...textData, x: 250, y: 125}
+    )
+  })
+
+  test('utils.fitCheckText shifts overflow', () => {
+    textData.x = 1000
+    assert.deepEqual(
+      fitCheckText(textData, width, height, defaultTheme),
+      {...textData, x: 975, y: 125}
+    )
+  })
+
+  test('utils.fitCheckText shifts underflow', () => {
+    textData.textAlign = 'right'
+    textData.x = 10
+    assert.deepEqual(
+      fitCheckText(textData, width, height, defaultTheme),
+      {...textData, x: 25, y: 125}
+    )
+  })
+
+  test('utils.fitCheckText shifts rotated overflow', () => {
+    textData.rotate = -Math.PI / 2
+    textData.y = 10
+    assert.deepEqual(
+      fitCheckText(textData, width, height, defaultTheme),
+      {...textData, x: 250, y: 25}
+    )
+  })
+
+  test('utils.fitCheckText shifts rotated underflow', () => {
+    textData.rotate = -Math.PI / 2
+    textData.y = 980
+    textData.textAlign = 'right'
+    assert.deepEqual(
+      fitCheckText(textData, width, height, defaultTheme),
+      {...textData, x: 250, y: 975}
+    )
+  })
+
+  test('utils.fitCheckText does not shift if rotated fits on canvas', () => {
+    textData.rotate = -Math.PI / 2
+    textData.y = 15
+    textData.textAlign = 'right'
+    assert.deepEqual(
+      fitCheckText(textData, width, height, defaultTheme),
+      {...textData, x: 250, y: 15}
+    )
+  })
+
+  describe('handles centered text', () => {
+    beforeEach(() => {
+      textData.textAlign = 'center'
+    })
+
+    test('with overflow', () => {
+      textData.x = 990
+      assert.deepEqual(
+        fitCheckText(textData, width, height, defaultTheme),
+        {...textData, x: 987.5, y: 125}
+      )
+    })
+
+    test('with underFlow', () => {
+      textData.x = 5
+      assert.deepEqual(
+        fitCheckText(textData, width, height, defaultTheme),
+        {...textData, x: 12.5, y: 125}
+      )
+    })
+  })
+
+  describe('handles offsets', () => {
+    test('that fit the canvas', () => {
+      textData.xOffset = -100
+      textData.x = 1000
+      assert.deepEqual(
+        fitCheckText(textData, width, height, defaultTheme),
+        {...textData, x: 900, y: 125}
+      )
+    })
+
+    test('x underflow with offset', () => {
+      textData.xOffset = -100
+      textData.x = 50
+      assert.deepEqual(
+        fitCheckText(textData, width, height, defaultTheme),
+        {...textData, x: 0, y: 125}
+      )
+    })
+
+    test('y overflow with offset', () => {
+      textData.yOffset = -50
+      textData.rotate = -Math.PI / 2
+      textData.y = 50
+      assert.deepEqual(
+        fitCheckText(textData, width, height, defaultTheme),
+        {...textData, x: 250, y: 25}
+      )
+    })
+
+    test('that do not impact overflow or underflow', () => {
+      textData.yOffset = -45
+      textData.y = 45
+      assert.deepEqual(
+        fitCheckText(textData, width, height, defaultTheme),
+        {...textData, x: 250, y: 0}
+      )
+    })
+  })
+})


### PR DESCRIPTION
Fixes #9 by fit checking text layers against the canvas size and shifting accordingly. Handles overflow and underflow of text that is horizontal or vertical as well as with offsets that might move it off the canvas.

Before:
<img width="385" alt="screen shot 2017-08-01 at 8 48 24 pm" src="https://user-images.githubusercontent.com/9057935/28853109-324fb076-76fc-11e7-8627-10978a37821b.png">

After:
<img width="386" alt="screen shot 2017-08-01 at 8 44 16 pm" src="https://user-images.githubusercontent.com/9057935/28853113-37a7315c-76fc-11e7-92c4-b748cd107ba2.png">
