### PR TITLE
Show breaks in lines and areas when values are null

### DIFF
--- a/src/Layer/areas/index.js
+++ b/src/Layer/areas/index.js
@@ -5,9 +5,8 @@ import _ from 'lodash'
 import {getMaxY} from '../../utils/rectUtils'
 import {getPath2D} from '../../utils/path2DUtils'
 import {getPlotValues} from '../../Layer/getPlotValues'
-import {isPlotNumber} from '../../utils'
-import {notPlotNumber} from '../../utils'
-import {plotValue} from '../../Layer/plotValue'
+import {isPlotNumber, notPlotNumber, splitBy} from '../../utils'
+import {plotValue, isNullPoint} from '../../Layer/plotValue'
 
 export const getPointData = (props, datum, yKey) => {
   const path2D = getPath2D()
@@ -119,11 +118,21 @@ export const getAreaRenderData = (props, data, idx) => {
     type: 'area',
   }
 }
+
+const splitDataAtNulls = (props, data) => {
+  const checkNullPoint = isNullPoint(props)
+  return _.reject(
+    splitBy(data, checkNullPoint).map(arr => _.reject(arr, checkNullPoint)),
+    _.isEmpty
+  )
+}
+
 export const areas = props => {
   if (!props.xScale || !props.yScale) return undefined
-  if (_.isArray(_.head(props.data))) {
+  const data = splitDataAtNulls(props, props.data)
+  if (_.isArray(_.head(data))) {
     return _.reduce(
-      props.data,
+      data,
       (acc, data, idx) => acc.concat(getAreaRenderData(props, data, idx)),
       []
     )

--- a/src/Layer/lines/index.js
+++ b/src/Layer/lines/index.js
@@ -82,12 +82,14 @@ const getLineRenderData = (props, data, idx) => {
     splineInterpolation(props, data, path2D)
   } else {
     path2D.moveTo(values.x, values.y)
-    _.each(data, d => {
+    _.reduce(data, (shouldDrawPoint, d) => {
       const x = plotValue(props, d, idx, 'x')
       const y = plotValue(props, d, idx, 'y')
-      if (notPlotNumber([x, y])) return
-      path2D.lineTo(x, y)
-    })
+      if (notPlotNumber([x, y])) return false
+      if (shouldDrawPoint) path2D.lineTo(x, y)
+      else path2D.moveTo(x, y)
+      return true
+    }, true)
   }
   return {
     ...values,

--- a/src/Layer/plotValue/index.js
+++ b/src/Layer/plotValue/index.js
@@ -42,6 +42,8 @@ It has the following resolution order:
 1. ${key}Value on the props
 2. scaled data accessed with the accessor
 3. ${key}Value on the data
+4. defaultValue from arguments
+5. value of datum[accessor] (can be undefined)
 */
 export const plotValue = (
   props, datum, idx, key, defaultValue
@@ -55,13 +57,20 @@ export const plotValue = (
 
   if (_.isFunction(value)) return value(props, datum, idx)
   if (isDatum(value)) return value
-  if (scale) {
-    const mappedValue = scale(_.get(datum, accessor))
-    if (isDatum(mappedValue)) return mappedValue
-  }
   const objValue = _.get(datum, accessor)
+  if (scale) {
+    const mappedValue = scale(objValue)
+    if (isDatum(mappedValue) && isDatum(objValue)) return mappedValue
+  }
   if (isDatum(objValue)) return objValue
   const objKeyValue = _.get(datum, `${key}Value`)
   if (isDatum(objKeyValue)) return objKeyValue
-  return defaultValue
+  return defaultValue || objValue
 }
+
+export const isNullPoint = props => (datum, idx) => (
+  plotValue(props, datum, idx, 'x', null) === null
+  || plotValue(props, datum, idx, 'x0', null) === null
+  || plotValue(props, datum, idx, 'y', null) === null
+  || plotValue(props, datum, idx, 'y0', null) === null
+)

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -28,3 +28,16 @@ export const notDatum = value => (
 )
 
 export const isDatum = value => !notDatum(value)
+
+// returns (start, end] as opposed to [].slice() returning [start, end)
+const slice = (arr, start, end) => arr.slice(start + 1, end + 1)
+
+export const splitBy = (arr, iteratee) => {
+  const {sliceFrom, returnArray} = _.reduce(arr, ({sliceFrom, returnArray}, val, idx) => {
+    if (iteratee(val, idx)) {
+      return {sliceFrom: idx, returnArray: [...returnArray, slice(arr, sliceFrom, idx)]}
+    }
+    return {sliceFrom, returnArray}
+  }, {sliceFrom: 0, returnArray: []})
+  return [...returnArray, slice(arr, sliceFrom, arr.length)]
+}


### PR DESCRIPTION
Previously, null y-values would be scaled to the bottom of the current
yScale. This change allows consumers the ability to pass null values to
create breaks in lines or areas.