### PR TITLE
Render tooltips within a portal appended to the root dom node

### DIFF
--- a/src/TooltipWrapper/index.js
+++ b/src/TooltipWrapper/index.js
@@ -6,6 +6,7 @@ import stateHOC from '../utils/stateHOC'
 import {getWindow} from '../utils/windowUtils'
 
 import {BlockSize} from '../utilComponents/BlockSize'
+import Portal from '../utilComponents/Portal'
 import {Tooltip as DefaultTooltip} from '../Tooltip'
 
 const TOOLTIP_MARGIN = 15
@@ -54,22 +55,24 @@ export const _TooltipWrapper = props => {
     Tooltip = DefaultTooltip,
   } = props.layerProps
   return (
-    <BlockSize
-      onUpdate={childProps => handleBlockSizeUpdate(props, childProps)}
-      style={{
-        margin: TOOLTIP_MARGIN,
-        pointerEvents: 'none',
-        position: 'fixed',
-        zIndex: '999999',
-        ...getTooltipPosition(props),
-      }}
-    >
-      <Tooltip
-        hoverData={props.hoverData}
-        layerProps={props.layerProps}
-        theme={props.theme}
-      />
-    </BlockSize>
+    <Portal>
+      <BlockSize
+        onUpdate={childProps => handleBlockSizeUpdate(props, childProps)}
+        style={{
+          margin: TOOLTIP_MARGIN,
+          pointerEvents: 'none',
+          position: 'fixed',
+          zIndex: '999999',
+          ...getTooltipPosition(props),
+        }}
+      >
+        <Tooltip
+          hoverData={props.hoverData}
+          layerProps={props.layerProps}
+          theme={props.theme}
+        />
+      </BlockSize>
+    </Portal>
   )
 }
 _TooltipWrapper.propTypes = {

--- a/src/utilComponents/Portal/index.js
+++ b/src/utilComponents/Portal/index.js
@@ -1,0 +1,28 @@
+import {Component} from 'react'
+import {unmountComponentAtNode, unstable_renderSubtreeIntoContainer as render} from 'react-dom'
+
+export default class Portal extends Component {
+
+  componentDidMount() {
+    this.container = document.createElement('div')
+    this.container.position = 'absolute'
+    this.container.top = 0
+    this.container.left = 0
+    this.container.right = 0
+    document.body.appendChild(this.container)
+    this.componentDidUpdate()
+  }
+
+  componentDidUpdate() {
+    render(this, <div {...this.props} />, this.container)
+  }
+
+  componentWillUnmount() {
+    unmountComponentAtNode(this.container)
+    this.container.remove()
+  }
+
+  render() {
+    return null
+  }
+}


### PR DESCRIPTION
Fixes #8.

In order to work around positioning issues in deeply nested elements, render tooltips within a 'portal' that renders its content as a child of the root dom node in a new React subtree.