### PR TITLE
Remove chartCore from public api

### DIFF
--- a/src/chartCore/getForKey.js
+++ b/src/chartCore/getForKey.js
@@ -5,15 +5,13 @@ import {isNumber, map, max, maxBy, min, reduce, toPairs, uniq} from 'lodash'
 import getMaxX from '../utils/rect/getMaxX'
 import getMaxY from '../utils/rect/getMaxY'
 
-import {getScale} from './getScale'
+import getScale from './getScale'
 import {DOMAIN, JS_TO_VIS_TYPE, TICK_COUNT, TICK_X_SPACE, TICK_Y_SPACE, TYPE} from './defaults'
 
 /*
 get methods that are used on the addMethods module
 addMethods add new properties to the props object, these new properties are generated using these getMethods.
 */
-
-export {getScale}
 
 export function toType(input) {
   return {}.toString

--- a/src/chartCore/getForProps.js
+++ b/src/chartCore/getForProps.js
@@ -2,15 +2,13 @@
 
 import {reduce} from 'lodash'
 
-import {getType, getDomain, getRange, getTickCount, getScale, getTickFormat} from './getForKey'
+import getScale from './getScale'
+import {getType, getDomain, getRange, getTickCount, getTickFormat} from './getForKey'
 
 /*
 Functions to be used on the Chart props transformation flow.
 The transformation flow starts with the <Chart /> props and successively adds the variables needed for plotting, the transformed props are used for generating render data.
 */
-
-export {default as getDimArrays} from './getDimArrays'
-export {getPlotRect} from './getPlotRect'
 
 export const getForProps = (value, getFunc) => props =>
   reduce(

--- a/src/chartCore/getScale.js
+++ b/src/chartCore/getScale.js
@@ -100,7 +100,7 @@ export function getDefaultScale(props, key) {
 }
 
 // main exported function, used outside of the module on the Chart props transform flow
-export function getScale(props, key) {
+export default function getScale(props, key) {
   switch (key) {
     case 'x':
     case 'y':

--- a/src/chartCore/index.js
+++ b/src/chartCore/index.js
@@ -1,6 +1,0 @@
-// Copyright 2018 Kensho Technologies, LLC.
-
-export * as getForKey from './getForKey'
-export * as getForProps from './getForProps'
-export * as getLayers from './getLayers'
-export * as getScale from './getScale'

--- a/src/index.js
+++ b/src/index.js
@@ -1,12 +1,13 @@
 // Copyright 2018 Kensho Technologies, LLC.
 
 export {default as DEFAULT_THEME} from './defaultTheme'
-export * as chartCore from './chartCore'
 
 export {default as labeler} from './utils/labeler'
 export {default as stateHOC} from './utils/stateHOC'
 export {default as withCachedContext} from './utils/withCachedContext'
 export {default as getPath2D} from './utils/getPath2D'
+
+export {getTicks} from './chartCore/getForKey'
 
 export {default as areas} from './Layer/areas'
 export {default as bars} from './Layer/bars'

--- a/test/chartCore/getScale.js
+++ b/test/chartCore/getScale.js
@@ -5,10 +5,9 @@ import assert from 'assert'
 import {it as test} from 'mocha'
 import {scalePoint} from 'd3-scale'
 
-import {
+import getScale, {
   getAxisScale,
   getDefaultScale,
-  getScale,
   getOrdinalInvert,
 } from '../../src/chartCore/getScale'
 


### PR DESCRIPTION
~~After thinking about this for a bit I believe it makes sense for orama to not export any of the `chartCore` functions. We currently only use one exported function from within the `chartCore` re-export and it can be replaced by a simplification to how the chart is being built.~~

We actually use `chartCore` in _two_ places, one of which is non-trivial to migrate. As a medium-term solution, we'll only export `getTicks`.

Closes #58 