### PR TITLE
Wrap sandbox in StrictMode

### DIFF
--- a/website/App.js
+++ b/website/App.js
@@ -34,7 +34,7 @@ Example.propTypes = {
 
 export default function App() {
   return (
-    <React.Fragment>
+    <React.StrictMode>
       <h1>Orama</h1>
       <div className="grid">
         <Example title="Lines" content={lines} />
@@ -54,6 +54,6 @@ export default function App() {
         <Example title="Hover effect" content={hoverEffect} />
         <Example title="Custom theme" content={customTheme} />
       </div>
-    </React.Fragment>
+    </React.StrictMode>
   )
 }


### PR DESCRIPTION
Closes #98 

One warning that popped out was the use of `cWRP`:
https://github.com/kensho-technologies/orama/blob/2a11ce3b914fb3db15d528058e3c9fd06ce77375/src/CanvasInput/index.js#L33