### PR TITLE
Fix brush out of bounds bug

### DIFF
--- a/src/CanvasInput/index.js
+++ b/src/CanvasInput/index.js
@@ -111,7 +111,7 @@ export default class CanvasInput extends React.Component {
       prevState => {
         const mouseDelta = prevState.mouse
           ? {x: prevState.mouse.x - mouse.x, y: prevState.mouse.y - mouse.y}
-          : null
+          : {x: 0, y: 0}
         return {
           mouseDrag: !!prevState.mouseDown,
           mouse,


### PR DESCRIPTION
Originally, `this.lastMouse` was never nullified and always stored the value of the last `mouse`. When the mouse left the bounds of the page it kept the `lastMouse` whereas in #120 it was switched to use `mouse`. 

To fix, we assume that whenever the user leaves the bounds of the chart and returns back, the `mouseDelta` should be reset to `{x: 0, y: 0}`

Closes #125 