### PR TITLE
Preserve mouse position on mouseLeave

### DIFF
--- a/src/CanvasInput/index.js
+++ b/src/CanvasInput/index.js
@@ -156,7 +156,6 @@ export default class CanvasInput extends React.Component {
   handleMouseLeave = () => {
     this.props.onUpdate({action: 'mouseLeave'})
     this.setState({
-      mouse: null,
       hoverRenderData: null,
       hoverData: null,
       layerProps: null,


### PR DESCRIPTION
Never nullifying `this.state.mouse` should be safe to do since when rendering a tooltip we check for `hoverData` which gets nullified on mouse leave.

Closes #129 