### PR TITLE
Scale dimension tooltip values correctly

### DIFF
--- a/src/chartCore/getRange.js
+++ b/src/chartCore/getRange.js
@@ -11,7 +11,7 @@ export default function getRange(props, key) {
     case 'y':
       return [getMaxY(plotRect), plotRect.y]
     case 'radius':
-      return type === 'ordinal' ? [2, 4, 8, 12, 16, 20] : [2, 20]
+      return type === 'ordinal' ? [2, 4, 8, 12, 16, 20] : [1, 20]
     case 'lineWidth':
       return type === 'ordinal' ? [1, 2, 3, 4] : [0.5, 4]
     case 'lineDash':

--- a/src/chartCore/getTooltipFormat.js
+++ b/src/chartCore/getTooltipFormat.js
@@ -17,5 +17,5 @@ export default function getTooltipFormat(props, key) {
   }
   if (type === 'time') return d => d.toDateString()
   if (!scale.tickFormat) return d => d
-  return scale.tickFormat(tickCount)
+  return tickCount ? scale.tickFormat(tickCount) : scale
 }

--- a/website/examples/horizontalColoredBars.js
+++ b/website/examples/horizontalColoredBars.js
@@ -12,6 +12,6 @@ const data = [
 
 export default (
   <Chart xZeroBased>
-    <Bars data={data} x="value" y="type" fill="value" />
+    <Bars data={data} x="value" y="type" fill="value" tooltipShowKeys />
   </Chart>
 )

--- a/website/examples/ranges.js
+++ b/website/examples/ranges.js
@@ -6,6 +6,14 @@ const data = [{start: 1, end: 5}, {start: 10, end: 20}, {start: 40, end: 50}, {s
 
 export default (
   <Chart>
-    <Ranges data={data} x1="start" x2="end" y1="start" y2="end" fillValue="lightgray" />
+    <Ranges
+      data={data}
+      x1="start"
+      x2="end"
+      y1="start"
+      y2="end"
+      fillValue="lightgray"
+      tooltipShowKeys
+    />
   </Chart>
 )


### PR DESCRIPTION
This issue ended up conflating two different issues.

The first is that [by default we do not show the `keys` row](https://github.com/kensho-technologies/orama#configuring-the-tooltip) on the tooltip. This causes dimensions we use the same data key accessor for to show up multiple times in the tooltip. For example, if we have a component `<Foo x=“bar” y=“baz” fill=“baz” />` then our tooltip will show `baz` twice, first for the`y` key and the second for `fill` key. This can be remedied by including the `tooltipShowKeys` prop which will give you the key along with the accessor key and datum value.

The second issue is that we return a `[dim]TickCount` of 0 for [all dimensions except `x` and `y`.](https://github.com/kensho-technologies/orama/blob/b1a9c0100661d8ddf11b323070007c63b355781f/src/chartCore/getTickCount.js#L18) 

When we later format the tooltip value for other dimensions, we apply a `tickFormat(0)` to the dimensions scale, which does not accurately reflect the scaled value we display in the chart. The solution is to only apply the `tickFormat` to scales where we have a `tickCount`.

I only added the `tooltipShowKeys` prop to a few examples but we can add it to others if we see the need to clarify the tooltip.

![screen shot 2018-06-12 at 12 55 05 pm](https://user-images.githubusercontent.com/9057935/41305101-e23e2ed2-6e3f-11e8-975b-59fad50483b5.png)

Closes #135 